### PR TITLE
fix: remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "set-value": "^3.0.1",
     "strind": "^0.3.0"
   },
-  "peerDependencies": {
-    "react": "^16.x",
-    "react-dom": "^16.x"
-  },
   "devDependencies": {
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",


### PR DESCRIPTION
Fixes #100

This removes react/react-dom as peer dependencies to prevent an NPM install error. when using React >=17.